### PR TITLE
Set MSRV to 1.64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.56.0  # MSRV
+          - 1.64.0  # MSRV
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://github.com/noeddl/ukebox"
 repository = "https://github.com/noeddl/ukebox"
 keywords = ["ukulele", "chords", "music", "cli"]
 categories = ["command-line-utilities"]
+rust-version = "1.64"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Documentation](https://docs.rs/ukebox/badge.svg)](https://docs.rs/ukebox)
 [![Continuous integration](https://github.com/noeddl/ukebox/actions/workflows/ci.yml/badge.svg)](https://github.com/noeddl/ukebox/actions/workflows/ci.yml)
 [![license](https://img.shields.io/crates/l/ukebox)](#license)
-[![rustc](https://img.shields.io/badge/rustc-1.56+-lightgray.svg)](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html)
+[![rustc](https://img.shields.io/badge/rustc-1.64+-lightgray.svg)](https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html)
 
 `ukebox` is a ukulele chord toolbox for the command line written in Rust.
 

--- a/src/chord_chart.rs
+++ b/src/chord_chart.rs
@@ -1,5 +1,6 @@
 use std::cmp::max;
 use std::fmt;
+use std::fmt::Write;
 
 use crate::{FretID, Semitones, UkeString, Voicing, MIN_CHART_WIDTH};
 
@@ -76,8 +77,10 @@ impl ChordChart {
                     "-".to_string()
                 }
             })
-            .map(|c| format!("-{}-|", c))
-            .collect();
+            .fold(String::new(), |mut output, c| {
+                let _ = write!(output, "-{c}-|");
+                output
+            });
 
         format!("{} {}{}{}- {}\n", root_str, sym, nut, s, note)
     }

--- a/src/voicing.rs
+++ b/src/voicing.rs
@@ -63,11 +63,7 @@ impl Voicing {
 
     /// Return the lowest fret at which a string is pressed down.
     pub fn get_min_pressed_fret(&self) -> FretID {
-        match self.frets().filter(|&x| x > 0).min() {
-            Some(x) => x,
-            // Special case [0, 0, 0, 0]: no string is pressed down.
-            _ => 0,
-        }
+        self.frets().filter(|&x| x > 0).min().unwrap_or_default()
     }
 
     /// Return the lowest fret involved in playing the chord voicing
@@ -338,6 +334,7 @@ mod tests {
 
     #[rstest(
         frets, min_pressed_fret, min_fret, max_fret, span,
+        // Special case [0, 0, 0, 0]: no string is pressed down.
         case([0, 0, 0, 0], 0, 0, 0, 0),
         case([1, 1, 1, 1], 1, 1, 1, 1),
         case([2, 0, 1, 3], 1, 0, 3, 3),


### PR DESCRIPTION
This allows for updating to clap 4 as is intended to be done in #123. Also, take care of clippy warnings to make the checks run through again.