### PR TITLE
Set MSRV to 1.74.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.64.0  # MSRV
+          - 1.74.1  # MSRV
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/noeddl/ukebox"
 repository = "https://github.com/noeddl/ukebox"
 keywords = ["ukulele", "chords", "music", "cli"]
 categories = ["command-line-utilities"]
-rust-version = "1.64"
+rust-version = "1.74"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Documentation](https://docs.rs/ukebox/badge.svg)](https://docs.rs/ukebox)
 [![Continuous integration](https://github.com/noeddl/ukebox/actions/workflows/ci.yml/badge.svg)](https://github.com/noeddl/ukebox/actions/workflows/ci.yml)
 [![license](https://img.shields.io/crates/l/ukebox)](#license)
-[![rustc](https://img.shields.io/badge/rustc-1.64+-lightgray.svg)](https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html)
+[![rustc](https://img.shields.io/badge/rustc-1.74+-lightgray.svg)](https://blog.rust-lang.org/2023/12/07/Rust-1.74.1.html)
 
 `ukebox` is a ukulele chord toolbox for the command line written in Rust.
 


### PR DESCRIPTION
As it turns out, clap 4.5 requires 1.74 (according to `cargo msrv`).